### PR TITLE
Domoticz no longer needs a 0-16 value for dimmers. Remove logic to cap t...

### DIFF
--- a/lib/Domo.pm
+++ b/lib/Domo.pm
@@ -81,7 +81,6 @@ debug($url);
 			return { success => false, errormsg => $response->status_line};
 		}
 } elsif ($actionName eq 'setLevel') {
-	#setLevel	0-100 => 0-16
 	#/json.htm?type=command&param=switchlight&idx=&switchcmd=Set%20Level&level=6
 	my $url;
 	if (($device_tab{$deviceId}->{"Action"}==2)or($device_tab{$deviceId}->{"Action"}==3)) {
@@ -111,8 +110,7 @@ debug($url);
 			$url=config->{domo_path}."/json.htm?type=command&param=switchlight&idx=$deviceId&switchcmd=On&level=$actionParam&passcode=";
 
 		} else {
-			my $valeur=ceil($actionParam*0.16);
-			$url=config->{domo_path}."/json.htm?type=command&param=switchlight&idx=$deviceId&switchcmd=Set%20Level&level=$valeur&passcode=";
+			$url=config->{domo_path}."/json.htm?type=command&param=switchlight&idx=$deviceId&switchcmd=Set%20Level&level=$actionParam&passcode=";
 		}
 	}
 


### PR DESCRIPTION
...he dimming value to that range.

See http://sourceforge.net/p/domoticz/code/2263/ for the commit that changed domoticz support for dimming ranges.